### PR TITLE
Minor configuration file reorganization

### DIFF
--- a/cmd/kubic-init/main.go
+++ b/cmd/kubic-init/main.go
@@ -99,8 +99,8 @@ func newBootstrapCmd(out io.Writer) *cobra.Command {
 				client, err := kubeconfigutil.ClientSetFromFile(kubeadmconstants.GetAdminKubeConfigPath())
 				kubeadmutil.CheckErr(err)
 
-				glog.V(1).Infof("[kubic] deploying CNI DaemonSet with '%s' driver", kubicCfg.Cni.Driver)
-				err = cni.Registry.Load(kubicCfg.Cni.Driver, kubicCfg, client)
+				glog.V(1).Infof("[kubic] deploying CNI DaemonSet with '%s' driver", kubicCfg.Network.Cni.Driver)
+				err = cni.Registry.Load(kubicCfg.Network.Cni.Driver, kubicCfg, client)
 				kubeadmutil.CheckErr(err)
 
 				// TODO: deploy Dex, etc...

--- a/configs/kubic-init.yaml
+++ b/configs/kubic-init.yaml
@@ -3,10 +3,6 @@
 ##
 apiVersion: kubic.suse.com/v1alpha2
 kind: KubicInitConfiguration
-# cni:
-#   driver: flannel
-#   podSubnet: "172.16.0.0/13"
-#   serviceSubnet: "172.24.0.0/16"
 # certificates:
 #   # a caCrt can be used for verifying the identity of the seeder
 #   caCrt:
@@ -16,3 +12,12 @@ kind: KubicInitConfiguration
 #   seeder: some-node.com
 #   # token for both discovery-token and tls-bootstrap-token
 #   token: 94dcda.c271f4ff502789ca
+# network:
+#   dns:
+#     domain: someDomain.local
+#     externalFqdn: some.name.com
+#   cni:
+#     driver: flannel
+#     podSubnet: "172.16.0.0/13"
+#     serviceSubnet: "172.24.0.0/16"
+#

--- a/pkg/cni/flannel/flannel.go
+++ b/pkg/cni/flannel/flannel.go
@@ -43,9 +43,9 @@ func EnsureFlannelAddon(cfg *config.KubicInitConfiguration, client clientset.Int
 	}
 
 	// Get the flannel subnet from the Network section of the kubeadm's master config
-	cidr_ip, cidr_net, err := net.ParseCIDR(cfg.Cni.PodSubnet)
+	cidr_ip, cidr_net, err := net.ParseCIDR(cfg.Network.Cni.PodSubnet)
 	if err != nil {
-		return fmt.Errorf("could not parse Pod CIDR from '%s': %v", cfg.Cni.PodSubnet, err)
+		return fmt.Errorf("could not parse Pod CIDR from '%s': %v", cfg.Network.Cni.PodSubnet, err)
 	}
 	cidr_len, _ := cidr_net.Mask.Size()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,9 +31,19 @@ type CertsConfiguration struct {
 	CaHash string `json:"caCrtHash,omitempty"`
 }
 
+type DNSConfiguration struct {
+	Domain       string   `json:"domain,omitempty"`
+	ExternalFqdn []string `json:"externalFqdn,omitempty"`
+}
+
+type NetworkConfiguration struct {
+	Cni CniConfiguration `json:"cni,omitempty"`
+	Dns DNSConfiguration `json:"dns,omitempty"`
+}
+
 // The kubic-init configuration
 type KubicInitConfiguration struct {
-	Cni              CniConfiguration              `json:"cni,omitempty"`
+	Network          NetworkConfiguration          `json:"network,omitempty"`
 	ClusterFormation ClusterFormationConfiguration `json:"clusterFormation,omitempty"`
 	Certificates     CertsConfiguration            `json:"certificates,omitempty"`
 }
@@ -101,19 +111,19 @@ func ConfigFileAndDefaultsToKubicInitConfig(cfgPath string) (*KubicInitConfigura
 	}
 
 	// Load the CNI configuration (or set default values)
-	if len(internalcfg.Cni.Driver) == 0 {
+	if len(internalcfg.Network.Cni.Driver) == 0 {
 		glog.V(3).Infof("[kubic] using default CNI driver %s", DefaultCniDriver)
-		internalcfg.Cni.Driver = DefaultCniDriver
+		internalcfg.Network.Cni.Driver = DefaultCniDriver
 	}
 
 	// Set some networking defaults
-	if len(internalcfg.Cni.PodSubnet) == 0 {
+	if len(internalcfg.Network.Cni.PodSubnet) == 0 {
 		glog.V(3).Infof("[kubic] using default Pods subnet %s", DefaultPodSubnet)
-		internalcfg.Cni.PodSubnet = DefaultPodSubnet
+		internalcfg.Network.Cni.PodSubnet = DefaultPodSubnet
 	}
-	if len(internalcfg.Cni.ServiceSubnet) == 0 {
+	if len(internalcfg.Network.Cni.ServiceSubnet) == 0 {
 		glog.V(3).Infof("[kubic] using default services subnet %s", DefaultServiceSubnet)
-		internalcfg.Cni.ServiceSubnet = DefaultServiceSubnet
+		internalcfg.Network.Cni.ServiceSubnet = DefaultServiceSubnet
 	}
 
 	glog.V(8).Infof("kubic-init configuration:\n%s", spew.Sdump(internalcfg))
@@ -123,7 +133,7 @@ func ConfigFileAndDefaultsToKubicInitConfig(cfgPath string) (*KubicInitConfigura
 
 // Copy some settings to a master configuration
 func KubicInitConfigToMasterConfig(kubicCfg *KubicInitConfiguration, masterCfg *kubeadmapiv1alpha2.MasterConfiguration) error {
-	masterCfg.Networking.PodSubnet = kubicCfg.Cni.PodSubnet
+	masterCfg.Networking.PodSubnet = kubicCfg.Network.Cni.PodSubnet
 
 	if len(kubicCfg.ClusterFormation.Token) > 0 {
 		glog.V(8).Infof("[kubic] adding a default bootstrap token: %s", kubicCfg.ClusterFormation.Token)


### PR DESCRIPTION
Reorganize the configuration file, creating a top level `network` section, with `cni` and `dns` subsections.