### PR TITLE
Favor simplicity over to much statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Description
 
-The Kubic-init repository is a project geared at simplifying the process of creating and maintaining kubernetes clusters. Our goal is to make the process as simple as possible using existing tools and developing new ones. The project has taken a highly opinionated approach to topics like security and other things we believe are important for easy maintenance of a cluster. Kubic-init is being actively developed/tested on top of the [Kubic project](https://en.opensuse.org/Portal:Kubic) but in theory could work on any linux based OS in the future.
+The Kubic-init repository is a project geared at simplifying the process of creating and maintaining kubernetes clusters. Kubic-init is being actively developed/tested on top of the [Kubic project](https://en.opensuse.org/Portal:Kubic).
 
 # Documentation
 


### PR DESCRIPTION
In this PR i remove 3 statements.

1) The goal statement is to much generic ( for me is better remove it)
2) The statement about security, is imho something better to don't mention it because it will give more a bad impression
3) I remove the `in theory` it should work for other OS. ( in opensource either you state what you support or you don't say in `theory` ambiguous statement). This in `theory` as user would give me a bad feeling

I had the feeling that trying to say to much over our intents would be more harmful for us then leave some statements opens.  I followed also what i see in upstream projects 