### PR TITLE
removed lines that no longer exist and caused docker to fail.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ RUN \
 # (check the .dockerignore file for exclusions)
 
 # Copy all the static files
-ADD config/crds      /usr/lib/kubic/crds
-ADD config/rbac      /usr/lib/kubic/rbac
 ADD config/manifests /usr/lib/kubic/manifests
 
 ### TODO: do not build the kubic-init exec IN this container:


### PR DESCRIPTION
Why we need this: I found the project no longer had `config/crds` or `config/rbac` folders. this caused the docker file to error when building.

Removal of these fixed the docker file and let it build.