### PR TITLE
DOCKER: Ignore files only without excluding all

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,14 @@
-# exclude everything
-**
-
-# ... except some key files/directories:
-!/cmd/**
-!/build/**
-!/config/**
+# ignore all this
+cover.out
+deployments/**
+Dockerfile
+docs/**
+go.*
+hack/**
+init/**
+kubic-init-latest.*
+LICENSE
+Makefile
+pkg/**
+PROJECT
+README.md


### PR DESCRIPTION
## What does this PR change?

With the previous behaviour, strange but true we were not old Docker backwards compatible (:pig_nose: :rosette: ) .

For example, in our worker we had this strange error:
Had a look at this https://ci.suse.de/view/CaaSP/job/kubic-init/94/console

We could not found a file.

I could not reproduce this on my workstation.

The story is that:
**strange behaviour worker**
```
Client:
 Version:      1.12.1
 API version:  1.24
 Go version:   go1.6.1
 Git commit:   8eab29e
 Built:        
 OS/Arch:      linux/amd64

Server:
 Version:      1.12.1
 API version:  1.24
 Go version:   go1.6.1
 Git commit:   8eab29e
 Built:        
 OS/Arch:      linux/amd64
```

my workstation
```
Client:
 Version:      17.09.1-ce
 API version:  1.32
 Go version:   go1.8.7
 Git commit:   f4ffd2511ce9
 Built:        Mon Jul 30 12:00:00 2018
 OS/Arch:      linux/amd64

Server:
 Version:      17.09.1-ce
 API version:  1.32 (minimum version 1.12)
 Go version:   go1.8.7
 Git commit:   f4ffd2511ce9
 Built:        Mon Jul 30 12:00:00 2018
 OS/Arch:      linux/amd64
 Experimental: false

```
