### PR TITLE
corrected lint issues in crypto, loader, and util

### DIFF
--- a/pkg/crypto/password.go
+++ b/pkg/crypto/password.go
@@ -38,6 +38,7 @@ var (
 	sharedPasswordDefaultLen = 16
 )
 
+// SharedPassword struct
 type SharedPassword struct {
 	Name     string // The name includes the "namespace" (ie, "kube-system/dex-velum")
 	length   int
@@ -58,6 +59,7 @@ func randStringRunes(n int) string {
 	return string(b)
 }
 
+// NewSharedPassword returns a new SharedPassword struct
 func NewSharedPassword(name, namespace string) SharedPassword {
 	if len(namespace) == 0 {
 		namespace = sharedPasswordNamespace
@@ -67,6 +69,7 @@ func NewSharedPassword(name, namespace string) SharedPassword {
 	}
 }
 
+// Rand returns a new password of langth
 func (password *SharedPassword) Rand(length int) (string, error) {
 	if length == 0 {
 		length = sharedPasswordDefaultLen
@@ -75,10 +78,12 @@ func (password *SharedPassword) Rand(length int) (string, error) {
 	return password.contents, nil
 }
 
+// GetName returns the name
 func (password SharedPassword) GetName() string {
 	return util.StringToNamespacedName(password.Name).Name
 }
 
+// GetNamespace returns the namespace
 func (password SharedPassword) GetNamespace() string {
 	return util.StringToNamespacedName(password.Name).Namespace
 }
@@ -115,6 +120,7 @@ func (password *SharedPassword) GetFromSecret(cli clientset.Interface) error {
 	return nil
 }
 
+// AsSecretReference returns the SharedPassword in the form of a corev1.SecretReference
 func (password *SharedPassword) AsSecretReference() corev1.SecretReference {
 	return corev1.SecretReference{
 		Name:      password.GetName(),
@@ -122,6 +128,7 @@ func (password *SharedPassword) AsSecretReference() corev1.SecretReference {
 	}
 }
 
+// Delete deletes
 func (password *SharedPassword) Delete(cli clientset.Interface) error {
 	err := cli.CoreV1().Secrets(password.GetNamespace()).Delete(password.GetName(), &metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {

--- a/pkg/crypto/service_cert.go
+++ b/pkg/crypto/service_cert.go
@@ -79,7 +79,7 @@ func NewAutoCert(ips []net.IP, names []string, name, namespace string) (*AutoCer
 	}, nil
 }
 
-// NewAutoCert creates a new automatically-signed service certificate
+// NewServiceCertFromReference creates a new automatically-signed service certificate
 func NewServiceCertFromReference(ref corev1.SecretReference) (*AutoCert, error) {
 	return &AutoCert{
 		SecretName:      ref.Name,
@@ -88,10 +88,12 @@ func NewServiceCertFromReference(ref corev1.SecretReference) (*AutoCert, error) 
 	}, nil
 }
 
+// GetName returns the SecretName
 func (ac AutoCert) GetName() string {
 	return ac.SecretName
 }
 
+// GetNamespace returns the secret namespace
 func (ac AutoCert) GetNamespace() string {
 	return ac.SecretNamespace
 }

--- a/pkg/loader/rbac.go
+++ b/pkg/loader/rbac.go
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+
 package loader
 
 import (
@@ -53,7 +54,7 @@ type RBACInstallOptions struct {
 	ErrorIfPathMissing bool
 }
 
-// necessary until https://github.com/kubernetes-sigs/controller-tools/pull/77 is merged
+// InstallRBAC necessary until https://github.com/kubernetes-sigs/controller-tools/pull/77 is merged
 func InstallRBAC(kubicCfg *kubiccfg.KubicInitConfiguration, config *rest.Config, options RBACInstallOptions) error {
 
 	cs, err := clientset.NewForConfig(config)

--- a/pkg/util/names.go
+++ b/pkg/util/names.go
@@ -30,6 +30,7 @@ const (
 	defaultNamespace = metav1.NamespaceSystem
 )
 
+// NewNamespacedName returns a new types.NamespacedName struct
 func NewNamespacedName(name, namespace string) types.NamespacedName {
 	return types.NamespacedName{
 		Name:      name,
@@ -37,6 +38,7 @@ func NewNamespacedName(name, namespace string) types.NamespacedName {
 	}
 }
 
+// NamespacedNameToString Returns the string [Namespace/Name]
 func NamespacedNameToString(ns types.NamespacedName) string {
 	if len(ns.Namespace) > 0 {
 		return fmt.Sprintf("%s/%s", ns.Namespace, ns.Name)
@@ -44,7 +46,7 @@ func NamespacedNameToString(ns types.NamespacedName) string {
 	return ns.Name
 }
 
-// ParseId parses a Kubernetes resource name as Namespace and Name
+// StringToNamespacedName parses a Kubernetes resource name as Namespace and Name
 func StringToNamespacedName(name string) types.NamespacedName {
 	nname := ""
 	nnamespace := ""
@@ -58,11 +60,13 @@ func StringToNamespacedName(name string) types.NamespacedName {
 	return types.NamespacedName{Name: nname, Namespace: nnamespace}
 }
 
+// ObjNamespacer interface
 type ObjNamespacer interface {
 	GetName() string
 	GetNamespace() string
 }
 
+// NamespacedObjToNamespacedName returns a types.NamespacedName
 func NamespacedObjToNamespacedName(obj ObjNamespacer) types.NamespacedName {
 	return types.NamespacedName{
 		Name:      obj.GetName(),
@@ -70,6 +74,7 @@ func NamespacedObjToNamespacedName(obj ObjNamespacer) types.NamespacedName {
 	}
 }
 
+// NamaspacedObjToMeta returns a metav1.ObjectMeta struct
 func NamaspacedObjToMeta(obj ObjNamespacer) metav1.ObjectMeta {
 	ns := NamespacedObjToNamespacedName(obj)
 	return metav1.ObjectMeta{
@@ -78,6 +83,7 @@ func NamaspacedObjToMeta(obj ObjNamespacer) metav1.ObjectMeta {
 	}
 }
 
+// NamespacedObjToString returns a string of the NamespacedObj in the form [Namesapce/Name]
 func NamespacedObjToString(obj ObjNamespacer) string {
 	if len(obj.GetNamespace()) > 0 {
 		return fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -22,17 +22,19 @@ import (
 	"strings"
 )
 
-// SafeId returns a safe ID (for example, for using in YAML)
+// SafeID returns a safe ID (for example, for using in YAML)
 // ie, "something:6000/ddd" becommes "something-6000-ddd"
-func SafeId(s string) string {
+func SafeID(s string) string {
 	replacer := strings.NewReplacer(" ", "-", ":", "-", "/", "-", ".", "-")
 	return replacer.Replace(s)
 }
 
+// URL64encode returns a base64 encoded string
 func URL64encode(v string) string {
 	return base64.RawURLEncoding.EncodeToString([]byte(v))
 }
 
+// URL64decode returns a decoded base 64 string
 func URL64decode(v string) string {
 	data, err := base64.RawURLEncoding.DecodeString(v)
 	if err != nil {
@@ -41,6 +43,7 @@ func URL64decode(v string) string {
 	return string(data)
 }
 
+// RemoveDuplicates removes duplicates from a map and returns a new map
 func RemoveDuplicates(in []string) []string {
 	processed := map[string]struct{}{}
 

--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -67,7 +67,7 @@ func ParseTemplate(templateStr string, replacements interface{}) (string, error)
 			return URL64decode(v)
 		},
 		"safeYAMLId": func(v string) string {
-			return SafeId(v)
+			return SafeID(v)
 		},
 		"safePath": safePath,
 	}


### PR DESCRIPTION
## What does this PR change?
Fixes lint issues so https://github.com/kubic-project/kubic-init/pull/106 can pass CI.
Fixes lint errors only found under `crypto`, `loader`, and `util`