### PR TITLE
Revert "Use leap15 as docker image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM opensuse/leap:15.0
-
+FROM opensuse:tumbleweed
 
 ENV SYSTEMCTL_FORCE_BUS 1
 ENV DBUS_SYSTEM_BUS_ADDRESS unix:path=/var/run/dbus/system_bus_socket


### PR DESCRIPTION
Reverts kubic-project/kubic-init#109

As discussed we cannot have this for `kubic-init` : leap15 cannot build the latest kubeadm  api pkgs

For operators leap15 is ok