### PR TITLE
Add e2e tests skeleton: 1st minimal test check cluster basics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ robots.txt*
 config/rbac/*
 config/crds/*
 cover.out
+*.coverprofile

--- a/docs/devel.md
+++ b/docs/devel.md
@@ -1,13 +1,5 @@
 # Development environment for `kubic-init`
 
-## Community
-
-Currently the Kubic-init project lives inside the kubic echosystem.
-
-If you have a question to ask? Want to join in the disscussion? Find community information including chat and mailing lists on the main [Kubic](https://en.opensuse.org/Portal:Kubic) page.
-
-Want to get involved but don't know what to do? Try looking at our github [issues](https://github.com/kubic-project/kubic-init/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) and use the tags `good first issue` or `help wanted`!
-
 ## Project structure
 
 This project follows the conventions presented in the [standard Golang
@@ -35,28 +27,27 @@ A simple `make` should be enough. This should compile [the main
 function](../cmd/kubic-init/main.go) and generate a `kubic-init` binary as
 well as a _Docker_ image.
 
-## Making a Pull Request
-
-Have a PR(Pull Request) you would like to make to the project? Here are a few helpful tips to ensure that the PR moves along quickly!
-
- - make sure all files pass gofmt.
- - run the existing unit tests locally.
- - squash your commits into one. Our goal is to have one meaningful change per commit.
- - when making the PR, ensure you explain the reason for the PR and or link the issue it solves.
-
-## Running tests
+## Running unit-tests
 
 Unit tests can be run using `make test`
 
+## Run e2e tests
+
+Once you have a deployed cluster, you can run the e2e tests on this cluster.
+
+0) Deploy `make tf-full-apply`
+
+1) Once you have the cluster in `kubic-init/tests` directory do :
+
+```bash
+SEEDER=192.168.122.73 ./run_suites.sh
+```
+
+Developing test guide is here: [E2E-TESTS](../tests/README.md)
+
 ### Code Coverage:
 
-Run first the tests.
-
-Then you can visualize the profile in html format:
-
-`go tool cover -html=cover.out`
-
-or use the `make coverage` target
+Run first the tests. Then use `make coverage` for visualizing coverage.
 
 Feel free to read more about this on : https://blog.golang.org/cover.
 
@@ -164,3 +155,12 @@ have combinations of a seeder and regular nodes. For example:
    
 Once you are done with your cluster, a `make tf-*-destroy` will
 destroy the cluster.
+
+## Community
+
+Currently the Kubic-init project lives inside the kubic echosystem.
+
+If you have a question to ask? Want to join in the disscussion? Find community information including chat and mailing lists on the main [Kubic](https://en.opensuse.org/Portal:Kubic) page.
+
+Want to get involved but don't know what to do? Try looking at our github [issues](https://github.com/kubic-project/kubic-init/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) and use the tags `good first issue` or `help wanted`!
+

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,8 @@ require (
 	github.com/mholt/caddy v0.11.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
+	github.com/onsi/ginkgo v1.6.0
+	github.com/onsi/gomega v1.4.2
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/petar/GoLLRB v0.0.0-20130427215148-53be0d36a84c // indirect
@@ -56,7 +58,7 @@ require (
 	github.com/vishvananda/netlink v0.0.0-20171026164508-b2de5d10e38e // indirect
 	github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936 // indirect
 	github.com/yuroyoro/swalker v0.0.0-20160622113523-0a5950e9162f
-	golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16 // indirect
+	golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 // indirect
 	golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 // indirect
 	golang.org/x/net v0.0.0-20181029044818-c44066c5c816 // indirect
 	golang.org/x/oauth2 v0.0.0-20181031022657-8527f56f7107 // indirect

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,66 @@
+# End to End tests for Kubic-init
+
+This tests are BDD style, using ginkgo Kubernetes framework for doing specific `kubic-init` e2e tests.
+
+# Testsuites for kubic-init
+
+- cluster-health : this tests will check a `kubic-init` cluster health.
+
+# Prerequisites for e2e tests.
+
+0) you need to have deployed kubic-init. `make tf-full-apply` on root of this dir.
+
+1) Run the following script
+```bash
+SEEDER=192.168.122.73 ./run_suites.sh 
+```
+
+# Envinronment Variables supported
+
+Add here only needed variables. Try to autodectect and be minimalist.
+
+#### Mandatory
+`SEEDER`: MANDATORY- This will contain the IP adress of your master
+
+#### Optional
+`SEEDER_SSH_PWD`: OPTIONAL- This is the root password for connecting to your master via ssh, by default this is `linux`. Set this to change.
+
+# Architecture and design:
+
+A testsuite is a subdirectory of `tests` and exist conceptually like a indipendent microservice.
+
+The testsuite share only the `lib` directory which are utilty. 
+The Common library is stored on `lib` directory, You should try to put code there to make clean the specs.
+
+This testsuite can be executed indipendently from each framework of deployment. You need only the `kubic-init` source code.
+
+You need only to pass the SEEDER as env variable, and you can run the tests to any deployed `kubic-init` cluster outside in the wild.
+Alls hosts/vms should have sshd enabled on port 22. We use linux as std password but you can change it with the ENV.variable.
+
+# Developing New Tests:
+
+## Tests requirements:
+
+0) All tests should be idempotent, meanining you can run them XX times, you will have the same results.
+
+1) All tests can be run in parallel.
+
+2) All tests doesn't require or have dependencies each others. Meaining: we can change order in which tests are executed, results will be the same. There is no hidden dependency between tests.
+
+## Run the tests:
+
+```golang
+ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --cover --trace --race --progress
+```
+This will run all sub-suites in random order, random sub-test.
+
+## How to create a new suite:
+
+Generally we should avoid to create much subsuites if they are not needed. 
+
+0) Create a dir like `your_suite_name`
+1) Create a pkg accordingly inside the dir. This pkg should be empty, only containing `pkg services` as example.
+2) Use `ginkgo bootstrap` for createing the `testsuite` file
+3) Use `ginkgo generate name_test` for generating specs. 
+
+See upstream doc for further details.

--- a/tests/cluster-health/cluster_health.go
+++ b/tests/cluster-health/cluster_health.go
@@ -1,0 +1,1 @@
+package cluster_health

--- a/tests/cluster-health/cluster_health_suite_test.go
+++ b/tests/cluster-health/cluster_health_suite_test.go
@@ -1,0 +1,13 @@
+package cluster_health_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestClusterHealth(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ClusterHealth Suite")
+}

--- a/tests/cluster-health/master_test.go
+++ b/tests/cluster-health/master_test.go
@@ -1,0 +1,32 @@
+package cluster_health_test
+
+import (
+	"fmt"
+	"os"
+
+	. "github.com/kubic-project/kubic-init/tests/lib"
+	. "github.com/onsi/ginkgo"
+)
+
+var host string
+
+// use init function for reading IPs of cluster
+func init() {
+	host = os.Getenv("SEEDER")
+	if host == "" {
+		panic("SEEDER IP not set")
+	}
+}
+
+var _ = Describe("Check Master health", func() {
+	It("kubic-init systemd service is up and running", func() {
+		cmd := "systemctl is-active --quiet kubic-init.service"
+		output, err := RunCmd(host, cmd)
+		if err != nil {
+			fmt.Printf("[ERROR]: kubic-init.service failed")
+			panic(err)
+		}
+		fmt.Println(string(output))
+	})
+
+})

--- a/tests/lib/ssh.go
+++ b/tests/lib/ssh.go
@@ -1,0 +1,47 @@
+package lib
+
+import (
+	"os"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// RunCmd execute command on remote systems
+func RunCmd(host, command string) ([]byte, error) {
+	client, session, err := connectToHost("root", host)
+	if err != nil {
+		return nil, err
+	}
+	out, err := session.CombinedOutput(command)
+	if err != nil {
+		return out, err
+	}
+	client.Close()
+	return out, nil
+}
+
+// We assume that connection  ssh should be running on 22 port.
+// By default we use linux, via ENV var this can changed.
+func connectToHost(user, host string) (*ssh.Client, *ssh.Session, error) {
+	var sshPassword string
+	sshPassword = os.Getenv("SEEDER_SSH_PWD")
+	// check if User has set another ssh pwd, default is linux
+	if sshPassword == "" {
+		sshPassword = "linux"
+	}
+	sshConfig := &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{ssh.Password(sshPassword)},
+	}
+	sshConfig.HostKeyCallback = ssh.InsecureIgnoreHostKey()
+	client, err := ssh.Dial("tcp", host+":22", sshConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	session, err := client.NewSession()
+	if err != nil {
+		client.Close()
+		return nil, nil, err
+	}
+	return client, session, nil
+}

--- a/tests/run_suites.sh
+++ b/tests/run_suites.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+set -e
+
+if [[ -z "${SEEDER}" ]]; then
+  # set SEEDER var from ARGs if env var is empty
+  SEEDER=$1
+  # if ARG and ENV empty Error out
+  [ -n "$SEEDER" ] || ( echo "FATAL: must provide SEEDER variable as ENV or Arg" ; exit 1 ; )
+fi
+
+# this IP will be then read by golang using os.env
+export SEEDER
+ginkgo -r --randomizeAllSpecs --randomizeSuites --failFast --cover --trace --race --progress -v


### PR DESCRIPTION
## What does this PR change?

This PR create the whole minimal architecture for BDD tests using ginkgo.

We have a `lib` for ssh to hosts. 
We have a 1st initial test for checking that `kubic-init.service` is running without problems.

A 2nd test should copy the `admin.conf` file and implmented the `kubectl` check in the same testsuite.

However i will not be  able to do that, lacking of time, so i created a card linked #124 

Also documentation about how to contribute on this was added.


## Documentation
Doc added
