### PR TITLE
Remove sudo from virsh

### DIFF
--- a/.jenkins-ci/Jenkinsfile-master-e2e-kubic-test
+++ b/.jenkins-ci/Jenkinsfile-master-e2e-kubic-test
@@ -7,8 +7,6 @@ properties([
 
 pipeline {
   environment { 
-    // avoid root for virsh
-    IMG_SUDO = "TF_VAR_img_sudo_virsh=none"
     GOPATH= "$HOME/go"
     PATH = "$PATH:/usr/local/go/bin"
  
@@ -35,7 +33,7 @@ pipeline {
       stage('Kubic-init deploy') {
         steps {
                 echo 'Deploy kubic-init'
-                sh "${IMG_SUDO} make tf-full-apply"
+                sh "make tf-full-apply"
               }
         }
     }

--- a/deployments/support/tf/download-image.sh
+++ b/deployments/support/tf/download-image.sh
@@ -104,27 +104,6 @@ while [ $# -gt 0 ] ; do
     --debug)
       set -x
       ;;
-    --sudo-virsh)
-      case $2 in
-      local)
-        LOCAL_VIRSH="sudo virsh"
-        REM_VIRSH="virsh"
-        ;;
-      remote)
-        LOCAL_VIRSH="virsh"
-        REM_VIRSH="sudo virsh"
-        ;;
-      both)
-        LOCAL_VIRSH="sudo virsh"
-        REM_VIRSH="sudo virsh"
-        ;;
-      none)
-        LOCAL_VIRSH="virsh"
-        REM_VIRSH="virsh"
-        ;;
-      esac
-      shift
-      ;;
     *)
       echo "Unknown argument $1"
       exit 1

--- a/deployments/tf-libvirt-full/terraform.tf
+++ b/deployments/tf-libvirt-full/terraform.tf
@@ -55,11 +55,6 @@ variable "img_down_extra_args" {
   description = "Extra arguments for the images downloader"
 }
 
-variable "img_sudo_virsh" {
-  default     = "local"
-  description = "Run virsh wioth sudo on [local|remote|both]"
-}
-
 variable "img_regex" {
   type        = "string"
   default     = "kubeadm-cri-o-kvm-and-xen"
@@ -151,7 +146,7 @@ resource "null_resource" "download_kubic_image" {
   count = "${length(var.img_url_base) == 0 ? 0 : 1}"
 
   provisioner "local-exec" {
-    command = "../support/tf/download-image.sh --img-regex '${var.img_regex}' --libvirt-uri '${var.libvirt_uri}' --sudo-virsh '${var.img_sudo_virsh}' --src-base '${var.img_url_base}' --refresh '${var.img_refresh}' --local '${var.img}' --upload-to-img '${var.prefix}_base_${basename(var.img)}' --upload-to-pool '${var.img_pool}' --src-filename '${var.img_src_filename}' ${var.img_down_extra_args}"
+    command = "../support/tf/download-image.sh --img-regex '${var.img_regex}' --libvirt-uri '${var.libvirt_uri}' --src-base '${var.img_url_base}' --refresh '${var.img_refresh}' --local '${var.img}' --upload-to-img '${var.prefix}_base_${basename(var.img)}' --upload-to-pool '${var.img_pool}' --src-filename '${var.img_src_filename}' ${var.img_down_extra_args}"
   }
 }
 

--- a/deployments/tf-libvirt-nodes/terraform.tf
+++ b/deployments/tf-libvirt-nodes/terraform.tf
@@ -55,11 +55,6 @@ variable "img_down_extra_args" {
   description = "Extra arguments for the images downloader"
 }
 
-variable "img_sudo_virsh" {
-  default     = "local"
-  description = "Run virsh wioth sudo on [local|remote|both]"
-}
-
 variable "img_regex" {
   type        = "string"
   default     = "kubeadm-cri-o-kvm-and-xen"
@@ -140,7 +135,7 @@ resource "null_resource" "download_kubic_image" {
   count = "${length(var.img_url_base) == 0 ? 0 : 1}"
 
   provisioner "local-exec" {
-    command = "../support/tf/download-image.sh --img-regex '${var.img_regex}' --libvirt-uri '${var.libvirt_uri}' --sudo-virsh '${var.img_sudo_virsh}' --src-base '${var.img_url_base}' --refresh '${var.img_refresh}' --local '${var.img}' --upload-to-img '${var.prefix}_base_${basename(var.img)}' --upload-to-pool '${var.img_pool}' --src-filename '${var.img_src_filename}' ${var.img_down_extra_args}"
+    command = "../support/tf/download-image.sh --img-regex '${var.img_regex}' --libvirt-uri '${var.libvirt_uri}' --src-base '${var.img_url_base}' --refresh '${var.img_refresh}' --local '${var.img}' --upload-to-img '${var.prefix}_base_${basename(var.img)}' --upload-to-pool '${var.img_pool}' --src-filename '${var.img_src_filename}' ${var.img_down_extra_args}"
   }
 }
 


### PR DESCRIPTION
## What does this PR change?

This PR remove `sudo virsh` from Terraform deployment.

FIX #121 

For any errors, the user should configure libvirt accordingly and setting LIBVIRT_URI properly so we don' need sudo