### PR TITLE
WIP: Enable auto-detection  of IPS of generated VMs and run e2e tests of kubic-init

### DIFF
--- a/.jenkins-ci/Jenkinsfile-master-e2e-kubic-test
+++ b/.jenkins-ci/Jenkinsfile-master-e2e-kubic-test
@@ -11,19 +11,18 @@ pipeline {
     PATH = "$PATH:/usr/local/go/bin"
  
    }
-     agent {
-         node {
-          label 'kubic-init'
-          // we want to work on $GOPATH. Take care to run go get -u PRJ the 1st time to worker
-          customWorkspace '/home/jenkins/go/src/github.com/kubic-project/kubic-init'
-        }
-       }
-   // trigger ever 1 hours
-    triggers {
-        cron('H H/1 * * *')
-    }
-    stages {
-      
+   agent {
+       node {
+        label 'kubic-init'
+        // we want to work on $GOPATH. Take care to run go get -u PRJ the 1st time to worker
+        customWorkspace '/home/jenkins/go/src/github.com/kubic-project/kubic-init'
+      }
+   }
+   triggers {
+     cron('* */1 * * *')
+   }
+
+   stages {
       stage('Kubic-init build') {
         steps {
                 echo 'build kubic-init from src'
@@ -34,6 +33,12 @@ pipeline {
         steps {
                 echo 'Deploy kubic-init'
                 sh "make tf-full-apply"
+              }
+        }
+      stage('Kubic-init e2e tests') {
+        steps {
+                echo 'Run e2e tests for kubic-init'
+		sh "make tf-e2e-tests"
               }
         }
     }

--- a/build/make/runners.mk
+++ b/build/make/runners.mk
@@ -166,7 +166,12 @@ kubelet-reset: kubeadm-reset
 	$(SUDO) cp -f $(KUBELET_CONFIG) /var/lib/kubelet/config.yaml
 	@-rm -f $(MANIFEST_DIR)/$(MANIFEST_REM)
 
-
+#############################################################
+# End To End Tests
+#############################################################
+SEEDER := $(shell cd $(TF_LIBVIRT_FULL_DIR) && terraform output -json seeder 2>/dev/null | python -c 'import sys, json; print json.load(sys.stdin)["value"]' 2>/dev/null || echo "unknown")
+tf-e2e-tests:
+	cd tests && SEEDER=$(SEEDER) ./run_suites.sh
 #############################################################
 # Terraform deployments
 #############################################################

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/vishvananda/netlink v0.0.0-20171026164508-b2de5d10e38e // indirect
 	github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936 // indirect
 	github.com/yuroyoro/swalker v0.0.0-20160622113523-0a5950e9162f
-	golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 // indirect
+	golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9
 	golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 // indirect
 	golang.org/x/net v0.0.0-20181029044818-c44066c5c816 // indirect
 	golang.org/x/oauth2 v0.0.0-20181031022657-8527f56f7107 // indirect


### PR DESCRIPTION
## What does this PR change?

The goal of this PR is to enable the `e2e tests` in our CI.

For doing this, we need to have:

- [x] write the output.json of IPS of noded (terraform output)

- [ ] parse this variable and pass this via ENV to the `run-testuites.sh` script

- [ ] Finally we could create a `make e2e-tests` target which will englobe the 2 operations and this will used to pipeline.
