### PR TITLE
cni: split DefaultCniImage to cni based images

### DIFF
--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -206,6 +206,11 @@ func EnsureCiliumAddon(cfg *config.KubicInitConfiguration, client clientset.Inte
 		return fmt.Errorf("error when creating cilium secret  %v", err)
 	}
 
+	image := cfg.Network.Cni.Image
+	if len(image) == 0 {
+		image = config.DefaultCiliumImage
+	}
+
 	ciliumDaemonSetBytes, err = kubeadmutil.ParseTemplate(CiliumDaemonSet,
 		struct {
 			Image          string
@@ -214,7 +219,7 @@ func EnsureCiliumAddon(cfg *config.KubicInitConfiguration, client clientset.Inte
 			SecretName     string
 			ServiceAccount string
 		}{
-			cfg.Network.Cni.Image,
+			image,
 			cfg.Network.Cni.ConfDir,
 			cfg.Network.Cni.BinDir,
 			CiliumCertSecret,

--- a/pkg/cni/flannel/flannel.go
+++ b/pkg/cni/flannel/flannel.go
@@ -142,6 +142,11 @@ func EnsureFlannelAddon(cfg *config.KubicInitConfiguration, client clientset.Int
 		return fmt.Errorf("error when parsing flannel configmap template: %v", err)
 	}
 
+	image := cfg.Network.Cni.Image
+	if len(image) == 0 {
+		image = config.DefaultFlannelImage
+	}
+
 	flannelDaemonSetBytes, err = kubeadmutil.ParseTemplate(FlannelDaemonSet19,
 		struct {
 			Image          string
@@ -151,7 +156,7 @@ func EnsureFlannelAddon(cfg *config.KubicInitConfiguration, client clientset.Int
 			BinDir         string
 			ServiceAccount string
 		}{
-			cfg.Network.Cni.Image,
+			image,
 			1, // TODO: replace by some config arg
 			FlannelHealthPort,
 			cfg.Network.Cni.ConfDir,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -177,7 +177,6 @@ var defaultConfiguration = KubicInitConfiguration{
 			Driver:  DefaultCniDriver,
 			BinDir:  DefaultCniBinDir,
 			ConfDir: DefaultCniConfDir,
-			Image:   DefaultCniImage,
 		},
 	},
 	ClusterFormation: ClusterFormationConfiguration{

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -56,7 +56,8 @@ var DefaultCriSocket = map[string]string{
 const (
 	DefaultCniDriver = "flannel"
 
-	DefaultCniImage = "registry.opensuse.org/devel/caasp/kubic-container/container/kubic/flannel:0.9.1"
+	DefaultFlannelImage = "registry.opensuse.org/devel/caasp/kubic-container/container/kubic/flannel:0.9.1"
+	DefaultCiliumImage  = "registry.opensuse.org/devel/caasp/kubic-container/container/kubic/cilium:1.2"
 
 	// Default directory for CNI binaries
 	DefaultCniBinDir = "/var/lib/kubelet/cni/bin"


### PR DESCRIPTION
## What does this PR change?

split DefaultCniImage to DefaultFlannelImage and DefaultCiliumImage to ease configuration 
( Previous behaviour, Current behaviour etc).

## Documentation
- No documentation needed