### PR TITLE
cni: error out on unsupported cni driver

### DIFF
--- a/pkg/cni/plugins.go
+++ b/pkg/cni/plugins.go
@@ -18,6 +18,8 @@
 package cni
 
 import (
+	"fmt"
+
 	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/kubic-project/kubic-init/pkg/config"
@@ -41,7 +43,11 @@ func (registry registryMap) Has(name string) bool {
 
 // Load loads a registry
 func (registry registryMap) Load(name string, cfg *config.KubicInitConfiguration, client clientset.Interface) error {
-	return registry[name](cfg, client)
+	if registry.Has(name) {
+		return registry[name](cfg, client)
+	}
+
+	return fmt.Errorf("%s cni plugin is not supported", name)
 }
 
 // Registry is the Global Registry


### PR DESCRIPTION
## What does this PR change?
before the PR:
I1213 21:13:23.239255   32467 main.go:131] [kubic] deploying CNI
DaemonSet with 'flennel' driver
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xfb9de4]

goroutine 1 [running]:
github.com/kubic-project/kubic-init/pkg/cni.registryMap.Load(0xc00045e1b0,
0xc000567ef3, 0x7, 0xc00014c8c0, 0x14aadc0, 0xc000183560, 0x0, 0x0)
        /home/nirmoy/go/src/github.com/kubic-project/kubic-init/pkg/cni/plugins.go:44

## Documentation
- No documentation needed