### PR TITLE
Add some configuration vars to the container startup mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ KUBIC_INIT_CFG  = $(CURDIR)/config/kubic-init.yaml
 
 # These will be provided to the target
 KUBIC_INIT_VERSION    := 1.0.0
-KUBIC_INIT_BUILD      := `git rev-parse HEAD 2>/dev/null`
+KUBIC_INIT_BUILD      := $(shell git rev-parse HEAD 2>/dev/null)
 KUBIC_INIT_BRANCH     := $(shell git rev-parse --abbrev-ref HEAD 2> /dev/null  || echo 'unknown')
 KUBIC_INIT_BUILD_DATE := $(shell date +%Y%m%d-%H:%M:%S)
 
@@ -76,7 +76,8 @@ go-version-check:
 	@[ $(GO_VERSION_MAJ) -ge 2 ] || \
 		[ $(GO_VERSION_MAJ) -eq 1 -a $(GO_VERSION_MIN) -ge 11 ] || (echo "FATAL: Go version:$(GO_VERSION) does not support modules" ; exit 1 ; )
 
-$(KUBIC_INIT_EXE): $(KUBIC_INIT_MAIN_SRCS) $(DEEPCOPY_GENERATED_FILES) go-version-check
+$(KUBIC_INIT_EXE): $(KUBIC_INIT_MAIN_SRCS) $(DEEPCOPY_GENERATED_FILES)
+	@make go-version-check
 	@echo ">>> Building $(KUBIC_INIT_EXE)..."
 	$(GO) build $(KUBIC_INIT_LDFLAGS) -o $(KUBIC_INIT_EXE) $(KUBIC_INIT_MAIN)
 

--- a/build/make/10-terraform.mk
+++ b/build/make/10-terraform.mk
@@ -1,0 +1,96 @@
+TF_LIBVIRT_FULL_DIR  = deployments/tf-libvirt-full
+TF_LIBVIRT_NODES_DIR = deployments/tf-libvirt-nodes
+TF_ARGS_DEFAULT      = -input=false -auto-approve \
+					   -var 'kubic_init_image_tgz="$(IMAGE_TAR_GZ)"' \
+					   -var 'kubic_init_extra_args="$(KUBIC_INIT_EXTRA_ARGS)"'
+
+SSH_ARGS := -o "StrictHostKeyChecking=no"
+SSH_VMS  := $(shell command sshpass >/dev/null 2>&1 && echo "sshpass -p linux ssh $(SSH_ARGS)" || echo "ssh $(SSH_ARGS)")
+
+#############################################################
+# Terraform deployments
+#############################################################
+
+### Terraform full deplyment
+
+tf-full-plan:
+	cd $(TF_LIBVIRT_FULL_DIR) && terraform init && terraform plan
+
+#
+# Usage:
+# - create a only-one-seeder cluster:
+#   $ make tf-full-run TF_ARGS="-var nodes_count=0"
+# - create cluster with Docker:
+#   $ make tf-full-run TF_ARGS="-var kubic_init_runner=docker" \
+#    KUBIC_INIT_EXTRA_ARGS="--var Runtime.Engine=docker"
+#
+tf-full-run: tf-full-apply
+tf-full-apply: $(IMAGE_TAR_GZ)
+	@echo ">>> Deploying a full cluster with Terraform..."
+	cd $(TF_LIBVIRT_FULL_DIR) && terraform init && terraform apply $(TF_ARGS_DEFAULT) $(TF_ARGS)
+
+tf-full-reapply:
+	cd $(TF_LIBVIRT_FULL_DIR) && terraform init && terraform apply $(TF_ARGS_DEFAULT) $(TF_ARGS)
+
+tf-full-destroy:
+	cd $(TF_LIBVIRT_FULL_DIR) && terraform init && terraform destroy -force $(TF_ARGS_DEFAULT) $(TF_ARGS)
+
+tf-full-nuke:
+	-make tf-full-destroy
+	cd $(TF_LIBVIRT_FULL_DIR) && rm -f *.tfstate*
+
+### Terraform only-seeder deployment (shortcut for `nodes_count=0`)
+
+tf-seeder-plan:
+	-make tf-full-plan TF_ARGS="-var nodes_count=0 $(TF_ARGS)"
+
+#
+# Usage:
+# - create a seeder with a specific Token:
+#   $ env TOKEN=XXXX make tf-seeder-run
+#
+tf-seeder-run: tf-seeder-apply
+tf-seeder-apply:
+	@echo ">>> Deploying only-seeder with Terraform..."
+	@make tf-full-apply TF_ARGS="-var nodes_count=0 $(TF_ARGS)"
+
+tf-seeder-reapply:
+	@make tf-full-reapply TF_ARGS="-var nodes_count=0 $(TF_ARGS)"
+
+tf-seeder-destroy:
+	@make tf-full-destroy TF_ARGS="-var nodes_count=0 $(TF_ARGS)"
+
+tf-seeder-nuke: tf-full-nuke
+
+### Terraform only-nodes deployment
+
+tf-nodes-plan:
+	cd $(TF_LIBVIRT_NODES_DIR) && terraform init && terraform plan
+
+#
+# Usage:
+# - create only one node (ie, for connecting to the seeder started locally with `make local-run`):
+#   $ env TOKEN=XXXX make tf-nodes-run
+#
+tf-nodes-run: tf-nodes-apply
+tf-nodes-apply: $(IMAGE_TAR_GZ)
+	@echo ">>> Deploying only-nodes with Terraform..."
+	cd $(TF_LIBVIRT_NODES_DIR) && terraform init && terraform apply $(TF_ARGS_DEFAULT) $(TF_ARGS)
+
+tf-nodes-destroy: $(TF_LIBVIRT_NODES_DIR)/.terraform
+	cd $(TF_LIBVIRT_NODES_DIR) && terraform init && terraform destroy -force $(TF_ARGS_DEFAULT) $(TF_ARGS)
+
+tf-nodes-nuke:
+	-make tf-nodes-destroy
+	cd $(TF_LIBVIRT_NODES_DIR) && rm -f *.tfstate*
+
+#
+# some ssh convenience targets
+#
+SEEDER := $(shell cd $(TF_LIBVIRT_FULL_DIR) && terraform output -json seeder 2>/dev/null | python -c 'import sys, json; print json.load(sys.stdin)["value"]' 2>/dev/null)
+tf-ssh-seeder:
+	$(SSH_VMS) root@$(SEEDER)
+
+NODE0 := $(shell cd $(TF_LIBVIRT_FULL_DIR) && terraform output -json nodes 2>/dev/null | python -c 'import sys, json; print json.load(sys.stdin)["value"][0][0]' 2>/dev/null)
+tf-ssh-node-0:
+	@$(SSH_VMS) root@$(NODE0)

--- a/build/make/30-e2e.mk
+++ b/build/make/30-e2e.mk
@@ -1,0 +1,8 @@
+#############################################################
+# End To End Tests
+#############################################################
+
+SEEDER := $(shell cd $(TF_LIBVIRT_FULL_DIR) && terraform output -json seeder 2>/dev/null | python -c 'import sys, json; print json.load(sys.stdin)["value"]' 2>/dev/null || echo "unknown")
+tf-e2e-tests:
+	cd tests && SEEDER=$(SEEDER) ./run_suites.sh
+

--- a/config/manifests/registries-operator.url
+++ b/config/manifests/registries-operator.url
@@ -1,0 +1,2 @@
+https://raw.githubusercontent.com/kubic-project/registries-operator/master/deployments/registries-operator-full.yaml
+

--- a/deployments/support/tf/get-token.py
+++ b/deployments/support/tf/get-token.py
@@ -9,7 +9,7 @@ import os
 # use the TOKEN variable if preset
 token = os.environ.get('TOKEN')
 if token is None:
-    token = "%0x.%0x" % (random.SystemRandom().getrandbits(3*8),
-                         random.SystemRandom().getrandbits(8*8))
+    a = "%0x" % random.SystemRandom().getrandbits(13*8)
+    token = a[:6] + "." + a[6:22]
 
 print(json.dumps({'token': token}, indent=2))

--- a/deployments/support/tf/init.sh.tpl
+++ b/deployments/support/tf/init.sh.tpl
@@ -1,13 +1,68 @@
 #!/bin/bash
 
-sysctl --system
-systemctl daemon-reload
+# NOTE: these variables will be replaced by Terraform
+IMAGE="${kubic_init_image_name}"
+IMAGE_FILENAME="${kubic_init_image_tgz}"
+RUNNER=${kubic_init_runner}
+EXTRA_ARGS="${kubic_init_extra_args}"
+
+###################################################################################
+
+set_var() {
+    var="$1"
+    value="$2"
+    file="$3"
+
+    if [ -f $file ] ; then
+        echo ">>> Setting $var=$value in $file..."
+        sed -i 's|^\('"$var"'\)\ *=.*|\1 = '"$value"'|' $file
+    else
+        echo ">>> Creating new file $file, with $var=$value..."
+        echo "$var = $value" > $file
+    fi
+    # TODO: add a case for where the file exists but the var doesn't
+}
+
 mkdir -p /var/lib/etcd
+
+echo ">>> Setting up network..."
 echo br_netfilter > /etc/modules-load.d/br_netfilter.conf
 modprobe br_netfilter
 sysctl -w net.ipv4.ip_forward=1
-sed -i 's/driver = \"\"/driver = \"btrfs\"/' /etc/containers/storage.conf
-sed -i 's|plugin_dir = \".*\"|plugin_dir = \"/var/lib/kubelet/cni/bin\"|' /etc/crio/crio.conf
+
+echo ">>> Setting up crio..."
+set_var plugin_dir \"/var/lib/kubelet/cni/bin\" /etc/crio/crio.conf
 echo 'runtime-endpoint: unix:///var/run/crio/crio.sock' > /etc/crictl.yaml
-while ! podman load -i /tmp/${kubic_init_image} ; do echo '(will try to load the kubic-init image again)' ; sleep 5 ; done
+
+echo ">>> Setting up storage..."
+set_var driver \"btrfs\" /etc/containers/storage.conf
+
+echo ">>> Setting runner as $RUNNER..."
+[ -x /usr/bin/$RUNNER ] || ( echo "FATAL: /usr/bin/$RUNNER does not exist!!!" ; exit 1 ; )
+set_var KUBIC_INIT_RUNNER /usr/bin/$RUNNER /etc/sysconfig/kubic-init
+
+echo ">>> Loading the kubic-init image with $RUNNER from /tmp/$IMAGE_FILENAME..."
+while ! /usr/bin/$RUNNER load -i /tmp/$IMAGE_FILENAME ; do
+    echo ">>> (will try to load the kubic-init image again)"
+    sleep 5 
+done
+
+[ "$RUNNER" = "podman" ] && IMAGE="localhost/$IMAGE"
+echo ">>> Setting image as $IMAGE"
+set_var KUBIC_INIT_IMAGE "\"$IMAGE\"" /etc/sysconfig/kubic-init
+
+if [ -n "$EXTRA_ARGS" ] ; then
+    echo ">>> Setting kubic-init extra args = $EXTRA_ARGS"
+    set_var KUBIC_INIT_EXTRA_ARGS "\"$EXTRA_ARGS\"" /etc/sysconfig/kubic-init
+fi
+
+echo ">>> Enabling the kubic-init service..."
+sysctl --system
+systemctl daemon-reload
+systemctl enable kubelet
+
+[ "$RUNNER" = "podman" ] && \
+    systemctl enable --now crio || \
+    systemctl enable --now docker
+
 systemctl enable --now kubic-init

--- a/deployments/tf-libvirt-full/terraform.tf
+++ b/deployments/tf-libvirt-full/terraform.tf
@@ -98,14 +98,26 @@ variable "devel" {
 
 variable "kubic_init_image_name" {
   type        = "string"
-  default     = "localhost/kubic-project/kubic-init:latest"
+  default     = "kubic-project/kubic-init:latest"
   description = "the default kubic init image name"
 }
 
-variable "kubic_init_image" {
+variable "kubic_init_image_tgz" {
   type        = "string"
   default     = "kubic-init-latest.tar.gz"
   description = "a kubic-init container image"
+}
+
+variable "kubic_init_runner" {
+  type        = "string"
+  default     = "podman"
+  description = "the kubic-init runner: docker or podman"
+}
+
+variable "kubic_init_extra_args" {
+  type        = "string"
+  default     = ""
+  description = "extra args for the kubic-init bootstrap"
 }
 
 variable "seed_memory" {
@@ -132,7 +144,10 @@ data "template_file" "init_script" {
   template = "${file("../support/tf/init.sh.tpl")}"
 
   vars {
-    kubic_init_image = "${var.kubic_init_image}"
+    kubic_init_image_name = "${var.kubic_init_image_name}"
+    kubic_init_image_tgz  = "${var.kubic_init_image_tgz}"
+    kubic_init_runner     = "${var.kubic_init_runner}"
+    kubic_init_extra_args = "${var.kubic_init_extra_args}"
   }
 }
 
@@ -266,8 +281,8 @@ resource "null_resource" "upload_config_seeder" {
   }
 
   provisioner "file" {
-    source      = "../../${var.kubic_init_image}"
-    destination = "/tmp/${var.kubic_init_image}"
+    source      = "../../${var.kubic_init_image_tgz}"
+    destination = "/tmp/${var.kubic_init_image_tgz}"
   }
 
   # TODO: this is only for development
@@ -383,8 +398,8 @@ resource "null_resource" "upload_config_nodes" {
   }
 
   provisioner "file" {
-    source      = "../../${var.kubic_init_image}"
-    destination = "/tmp/${var.kubic_init_image}"
+    source      = "../../${var.kubic_init_image_tgz}"
+    destination = "/tmp/${var.kubic_init_image_tgz}"
   }
 
   # TODO: this is only for development

--- a/deployments/tf-libvirt-nodes/terraform.tf
+++ b/deployments/tf-libvirt-nodes/terraform.tf
@@ -96,10 +96,28 @@ variable "devel" {
   description = "enable some steps for development environments (non-empty=true)"
 }
 
-variable "kubic_init_image" {
+variable "kubic_init_image_name" {
+  type        = "string"
+  default     = "kubic-project/kubic-init:latest"
+  description = "the default kubic init image name"
+}
+
+variable "kubic_init_image_tgz" {
   type        = "string"
   default     = "kubic-init-latest.tar.gz"
   description = "a kubic-init container image"
+}
+
+variable "kubic_init_runner" {
+  type        = "string"
+  default     = "podman"
+  description = "the kubic-init runner: docker or podman"
+}
+
+variable "kubic_init_extra_args" {
+  type        = "string"
+  default     = ""
+  description = "extra args for the kubic-init bootstrap"
 }
 
 variable "default_node_memory" {
@@ -121,7 +139,10 @@ data "template_file" "init_script" {
   template = "${file("../support/tf/init.sh.tpl")}"
 
   vars {
-    kubic_init_image = "${var.kubic_init_image}"
+    kubic_init_image_name = "${var.kubic_init_image_name}"
+    kubic_init_image_tgz  = "${var.kubic_init_image_tgz}"
+    kubic_init_runner     = "${var.kubic_init_runner}"
+    kubic_init_extra_args = "${var.kubic_init_extra_args}"
   }
 }
 
@@ -266,8 +287,8 @@ resource "null_resource" "upload_config_nodes" {
   }
 
   provisioner "file" {
-    source      = "../../${var.kubic_init_image}"
-    destination = "/tmp/${var.kubic_init_image}"
+    source      = "../../${var.kubic_init_image_tgz}"
+    destination = "/tmp/${var.kubic_init_image_tgz}"
   }
 
   # TODO: this is only for development

--- a/init/kubic-init.sysconfig
+++ b/init/kubic-init.sysconfig
@@ -1,8 +1,40 @@
 # configuration file in /etc/sysconfig/kubic-init
 
+# the configuration file
+KUBIC_INIT_CFG = /etc/kubic/kubic-init.yaml
+
+# debug level (from 0 to ...)
+KUBIC_INIT_DEBUGLEVEL = 3
+
 # TODO: replace for an official image
 # FIXME: localhost needs changing if the container runtime is docker
-IMAGE_KUBIC_INIT="localhost/kubic-project/kubic-init:latest"
+KUBIC_INIT_IMAGE = "localhost/kubic-project/kubic-init:latest"
 
-# unified image for running hyperkube
-# IMAGE_UNIFIED_K8S=""
+# The runner for containers
+KUBIC_INIT_RUNNER = /usr/bin/podman
+
+# Arguments for the runner
+KUBIC_INIT_RUNNER_ARGS = "--privileged=true \
+                          --net=host \
+                          --security-opt seccomp:unconfined \
+                          --cap-add=SYS_ADMIN \
+                          --name=kubic-init"
+
+# Volumes to mount in the runner
+KUBIC_INIT_RUNNER_VOLS = "-v /etc/kubic:/etc/kubic \
+                          -v /etc/kubernetes:/etc/kubernetes \
+                          -v /usr/bin/kubelet:/usr/bin/kubelet:ro \
+                          -v /var/lib/kubelet:/var/lib/kubelet \
+                          -v /etc/cni/net.d:/etc/cni/net.d \
+                          -v /var/lib/etcd:/var/lib/etcd \
+                          -v /var/run/dbus:/var/run/dbus \
+                          -v /usr/lib/systemd:/usr/lib/systemd:ro \
+                          -v /run/systemd:/run/systemd:ro \
+                          -v /var/run/crio:/var/run/crio \
+                          -v /sys/fs/cgroup:/sys/fs/cgroup \
+                          -v /lib/modules:/lib/modules:ro"
+
+# Extra args for the `kubic-init bootstrap` command
+KUBIC_INIT_EXTRA_ARGS =
+
+

--- a/init/kubic-init.systemd.conf
+++ b/init/kubic-init.systemd.conf
@@ -1,16 +1,16 @@
 # save this file to /etc/systemd/system/kubic-init.service
 
 [Unit]
-Description=Kubic init Container
-After=crio.service
-Requires=crio.service
+Description=Kubic Initialization Container
+After=crio.service docker.service
 
 [Service]
 TimeoutStartSec=0
-RestartSec=5
+RestartSec=30
 
 # TODO: change to "always" for production systems
 Restart=on-failure
+SyslogIdentifier=kubic-init
 
 # TODO: see https://www.freedesktop.org/software/systemd/man/systemd.unit.html#OnFailure=
 # OnFailure=kubic-init-reset.service
@@ -18,28 +18,29 @@ Restart=on-failure
 # TODO: replace by a official image
 EnvironmentFile=-/etc/sysconfig/kubic-init
 
-ExecStartPre=-/usr/bin/podman stop kubic-init
-ExecStartPre=-/usr/bin/podman rm kubic-init
-ExecStart=/usr/bin/podman run --rm \
-                --privileged=true \
-                --net=host \
-                --security-opt seccomp:unconfined \
-                --cap-add=SYS_ADMIN \
-                --name=kubic-init \
-                -v /etc/kubic:/etc/kubic \
-                -v /etc/kubernetes:/etc/kubernetes \
-                -v /usr/bin/kubelet:/usr/bin/kubelet:ro \
-                -v /var/lib/kubelet:/var/lib/kubelet \
-                -v /etc/cni/net.d:/etc/cni/net.d \
-                -v /var/lib/etcd:/var/lib/etcd \
-                -v /var/run/dbus:/var/run/dbus \
-                -v /usr/lib/systemd:/usr/lib/systemd:ro \
-                -v /run/systemd:/run/systemd:ro \
-                -v /var/run/crio:/var/run/crio \
-                -v /sys/fs/cgroup:/sys/fs/cgroup \
-                -v /lib/modules:/lib/modules:ro \
-                $IMAGE_KUBIC_INIT \
-                kubic-init bootstrap --config=/etc/kubic/kubic-init.yaml
+ExecStartPre=-/bin/sh -c '${KUBIC_INIT_RUNNER} stop kubic-init >/dev/null 2>&1'
+ExecStartPre=-/bin/sh -c '${KUBIC_INIT_RUNNER} rm kubic-init >/dev/null 2>&1'
+
+# reset the environment if the node is not setup
+# TODO: we should skip this reset IFF the this node has been properly set up
+#       but... how do we know this node has been properly set up?
+#       maybe the `reset` should be part of the `bootstrap` in
+#       the `kubic-init` executable, and try to 1) connect to the API server
+#       2) check the nodename exists and 3) is ready
+ExecStartPre=-/bin/sh -c 'kubectl --kubeconfig=/etc/kubernetes/admin.conf cluster-info >/dev/null 2>&1 || \
+                          ${KUBIC_INIT_RUNNER} run --rm \
+                          ${KUBIC_INIT_RUNNER_ARGS} \
+                          ${KUBIC_INIT_RUNNER_VOLS} \
+                          ${KUBIC_INIT_IMAGE} \
+                          kubic-init reset --v ${KUBIC_INIT_DEBUGLEVEL} --config=${KUBIC_INIT_CFG} ${KUBIC_INIT_EXTRA_ARGS}'
+
+# TODO: we should skip this `bootstrap` if the node is already set up
+ExecStart=/bin/sh -c 'kubectl --kubeconfig=/etc/kubernetes/admin.conf cluster-info >/dev/null 2>&1 || \
+                      ${KUBIC_INIT_RUNNER} run --rm \
+                      ${KUBIC_INIT_RUNNER_ARGS} \
+                      ${KUBIC_INIT_RUNNER_VOLS} \
+                      ${KUBIC_INIT_IMAGE} \
+                      kubic-init bootstrap --v ${KUBIC_INIT_DEBUGLEVEL} --config=${KUBIC_INIT_CFG} ${KUBIC_INIT_EXTRA_ARGS}'
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -184,11 +184,13 @@ var DefaultKubeletSettings = map[string]string{
 // DefaultIgnoredPreflightErrors Hardcoded list of errors to ignore
 var DefaultIgnoredPreflightErrors = []string{
 	"Service-Docker",
+	"Service-Kubelet", // ignore the warning if the Kubelet is down
 	"Swap",
 	"FileExisting-crictl",
 	"Port-10250",
 	"SystemVerification", // for ignoring docker graph=btrfs
 	"IsPrivilegedUser",
+	"NumCPU", // we will not always have >=2 CPUs in our VMs
 }
 
 // DefaultFeatureGates Constant set of featureGates

--- a/pkg/loader/manifests.go
+++ b/pkg/loader/manifests.go
@@ -55,7 +55,7 @@ func getUnstructuredInYAMLFile(kubicCfg *kubiccfg.KubicInitConfiguration, fileCo
 
 	sepYamlfiles := strings.Split(fileContents, "---")
 	for _, f := range sepYamlfiles {
-		if f == "\n" || f == "" {
+		if f == "\n" || f == "" || strings.TrimSpace(f) == "" {
 			// ignore empty cases
 			continue
 		}
@@ -166,3 +166,4 @@ func InstallManifests(kubicCfg *kubiccfg.KubicInitConfiguration, config *rest.Co
 
 	return nil
 }
+


### PR DESCRIPTION
## What does this PR change?

* Add some configuration vars to the container startup mechanism (ie, we can pass `KUBIC_INIT_EXTRA_ARGS` from the local `make tf-full-apply` down to the `kubic-init bootstrap $KUBIC_INIT_EXTRA_ARGS`).
* Run the `kubic-init` container with docker/podman depending on a Terraform variable.
* Some minor cleanups

## Documentation

We can now pass some args to the `kubic-init bootstrap` command being run in the `kubic-init` container in the VMs. For example, using a different container engine in the VMs would be as simple as `make tf-full-apply KUBIC_INIT_EXTRA_ARGS="--var Runtime.Engine=docker"`

