### PR TITLE
cni: make default cni config placement configurable

### DIFF
--- a/cmd/kubic-init/main.go
+++ b/cmd/kubic-init/main.go
@@ -125,7 +125,7 @@ func newCmdBootstrap(out io.Writer) *cobra.Command {
 
 				if deployCNI {
 					glog.V(1).Infof("[kubic] preparing CNI")
-					err = cni.Prepare()
+					err = cni.Prepare(kubicCfg)
 					kubeadmutil.CheckErr(err)
 
 					glog.V(1).Infof("[kubic] deploying CNI DaemonSet with '%s' driver", kubicCfg.Network.Cni.Driver)


### PR DESCRIPTION
## What does this PR change?
default cni is always placed in /etc/cni/net.d/ which is wrong if  --var Network.Cni.ConfDir points to some other location
## Documentation
- No documentation needed
