### PR TITLE
test: minor pkg name fix

### DIFF
--- a/tests/cluster-health/cluster_health_suite_test.go
+++ b/tests/cluster-health/cluster_health_suite_test.go
@@ -1,4 +1,4 @@
-package clusterhealthtest
+package clusterhealth
 
 import (
 	"testing"

--- a/tests/cluster-health/master_test.go
+++ b/tests/cluster-health/master_test.go
@@ -1,4 +1,4 @@
-package clusterhealthtest
+package clusterhealth
 
 import (
 	"fmt"


### PR DESCRIPTION
## What does this PR change?
fix 

```golang

+ make tf-e2e-tests
Makefile:67: warning: overriding recipe for target 'pkg/config/zz_generated.deepcopy.go'
Makefile:67: warning: ignoring old recipe for target 'pkg/config/zz_generated.deepcopy.go'
GO111MODULE=off go get -u github.com/onsi/ginkgo/ginkgo
cd tests && SEEDER=192.168.122.167 ./run_suites.sh
Failed to compile cluster-health:

can't load package: package github.com/kubic-project/kubic-init/tests/cluster-health: found packages clusterhealth (cluster_health.go) and clusterhealthtest (cluster_health_suite_test.go) in /home/jenkins/go/src/github.com/kubic-project/kubic-init/tests/cluster-health

```