### PR TITLE
Replace deprecated image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse:tumbleweed
+FROM opensuse/tumbleweed:latest
 
 RUN \
   zypper ar --refresh --enable --no-gpgcheck https://download.opensuse.org/repositories/devel:/kubic/openSUSE_Tumbleweed extra-repo0 && \
@@ -24,4 +24,4 @@ VOLUME /sys/fs/cgroup
 ENV SYSTEMCTL_FORCE_BUS 1
 ENV DBUS_SYSTEM_BUS_ADDRESS unix:path=/var/run/dbus/system_bus_socket
 
-CMD /usr/local/bin/kubic-init
+CMD ["/usr/local/bin/kubic-init"]


### PR DESCRIPTION
## What does this PR change?

**add description**
#### Previous behaviour
```
$ docker save kubic-project/kubic-init  -o image.tar
Error response from daemon: open /var/lib/docker/btrfs/subvolumes/c41c8602605620de701b3bcf72abca9caabc0d05a462a07366fee86fe35070f2/bin/bash: no such file or directory
```


#### Current behaviour

Saves the images without errors

## Documentation
- No documentation needed:  Just replaces the base image
- How to test the feature: 

```
docker build -t kubic-project/kubic-init:latest .
docker save kubic-project/kubic-init:latest -o image.tar
```


## Test coverage
No needed

## Links
Not created
