### PR TITLE
Fix Kubernetes version and flannel image tag

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// DefaultKubernetesVersion Kubernetes version to deploy
-	DefaultKubernetesVersion = "1.13"
+	DefaultKubernetesVersion = "1.13.2"
 
 	// DefaultAPIServerPort Default API server port
 	DefaultAPIServerPort = 6443
@@ -56,7 +56,7 @@ var DefaultCriSocket = map[string]string{
 const (
 	DefaultCniDriver = "flannel"
 
-	DefaultFlannelImage = "registry.opensuse.org/devel/caasp/kubic-container/container/kubic/flannel:0.9.1"
+	DefaultFlannelImage = "registry.opensuse.org/devel/kubic/containers/container/kubic/flannel:0.9.1"
 	DefaultCiliumImage  = "registry.opensuse.org/devel/caasp/kubic-container/container/kubic/cilium:1.2"
 	DefaultMultusImage  = "registry.opensuse.org/devel/kubic/containers/container/kubic/multus:3.1"
 


### PR DESCRIPTION
- Fixes #177 by replacing '1.13' with '1.13.2' tag
- Fixes #182 by taking the flannel from 'devel:kubic:container'

## Links

Fixes #177 
Fixed #182 

